### PR TITLE
Routing update

### DIFF
--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -18,9 +18,12 @@ from django.urls import path
 from .views import createUserView, Homepage, loginUserView, user_logout, userInfo
 from django.conf.urls.static import static
 from django.conf import settings
+from django.views.generic import RedirectView
 
 urlpatterns = [
+    path("signup/",RedirectView.as_view(url='/signup'), name='signup'),
     path('', Homepage.as_view(), name='home'),
+    path("login/",RedirectView.as_view(url='/login'), name='login'),
     path('createuser/', createUserView, name='createuser'),
     path('authuser/', loginUserView, name='authuser'),
     path('logout/',user_logout, name='logout'),

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -20,11 +20,7 @@ from django.conf.urls.static import static
 from django.conf import settings
 
 urlpatterns = [
-    path("signup/",Homepage.as_view(), name='signup'),
-    path('signup', Homepage.as_view(), name='signup_noslash'),
     path('', Homepage.as_view(), name='home'),
-    path("login/",Homepage.as_view(), name='login'),
-    path('login', Homepage.as_view(), name='login'),
     path('createuser/', createUserView, name='createuser'),
     path('authuser/', loginUserView, name='authuser'),
     path('logout/',user_logout, name='logout'),

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -15,18 +15,24 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path
-from .views import createUserView, Homepage, loginUserView, user_logout, userInfo
+from .views import createUserView, Homepage, loginUserView, user_logout, userInfo, user_redirect
 from django.conf.urls.static import static
 from django.conf import settings
 from django.views.generic import RedirectView
 
 urlpatterns = [
-    path("signup/",RedirectView.as_view(url='/signup'), name='signup'),
     path('', Homepage.as_view(), name='home'),
-    path("login/",RedirectView.as_view(url='/login'), name='login'),
+
+    path("signup",user_redirect, name='signup'),
+    path("signup/",RedirectView.as_view(url='/signup'), name='signup-redirect'),
+
+    path("login",user_redirect, name='login'),
+    path("login/",RedirectView.as_view(url='/login'), name='login-redirect'),
+
+    path('logout/',user_logout, name='logout'),
+
     path('createuser/', createUserView, name='createuser'),
     path('authuser/', loginUserView, name='authuser'),
-    path('logout/',user_logout, name='logout'),
     path('user-Info/', userInfo.as_view(), name='user-info'),
 
     

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -67,6 +67,14 @@ class Homepage(TemplateView):
             return ['index.html']
         else:
             return ['app.html']
+
+def user_redirect(request):
+    if request.user.is_authenticated:
+        return redirect('/')
+    else:
+        return render(request, 'index.html')
+    
+
     
         
 

--- a/todo/urls.py
+++ b/todo/urls.py
@@ -14,14 +14,17 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path, include
+from django.urls import path, include, re_path
 from django.conf.urls.static import static
 from django.conf import settings
+from django.views.generic import TemplateView
 
 
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("", include('tasks.urls')),
     path("", include('accounts.urls')),
+    re_path(r'^.*', TemplateView.as_view(template_name='index.html')),
+
 ]+ static(settings.STATIC_URL, document_root=settings.STATICFILES_DIRS[0])
 


### PR DESCRIPTION
# Routing
All frontend paths are now handled by the SPA code, this is done by sending all requests that are not handled by django to `index.html`. 
```python
 re_path(r'^.*', TemplateView.as_view(template_name='index.html')),
```
this fixes: 

- custom 404 page
- refresh causing 404 to be returned on some pages
# Slash problem
Previously, if a slash followed an existing path, nothing was returned. for example, if `signup/` was used instead of `signup`, this problem arose. this was fixed by redirecting such paths to their correct alternative, from `signup/` to `signup`.
```python
path("signup/",RedirectView.as_view(url='/signup'), name='signup'),
```

# Authntication related routing

- Users are now redirected to home if they are logged in and try to access `login/` or `signup/`.
- fixes #31 .
